### PR TITLE
Processing .const statements

### DIFF
--- a/KickAssemblerToDoxygen.py
+++ b/KickAssemblerToDoxygen.py
@@ -71,6 +71,7 @@ def remove_inital_dot_from_keywords(content):
     content = content.replace('.macro ', 'macro ')
     content = content.replace('.function ', 'function ')
     content = content.replace('.label ', 'label ')
+    content = content.replace('.const ', 'const ')
     content = content.replace('.pseudocommand ', 'pseudocommand ')
     content = content.replace('.struct ', 'struct ')
 
@@ -89,6 +90,13 @@ def add_semicolon_to_label_declaration(content):
     """Function printing python version."""
     # add semicolon at the end of label declaration
     content = re.sub(r'(label[^\n\,]+)', r'\1;', content)
+
+    return content
+
+def add_semicolon_to_const_declaration(content):
+    """Function printing python version."""
+    # add semicolon at the end of const declaration
+    content = re.sub(r'(const[^\n\,]+)', r'\1;', content)
 
     return content
 
@@ -130,6 +138,8 @@ def convert_file(content):
     content = remove_inital_dot_from_keywords(content)
 
     content = add_semicolon_to_label_declaration(content)
+    
+    content = add_semicolon_to_const_declaration(content)
 
     content = remove_some_newline(content)
     return content

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ This script removes:
 
 After removing all these stuff, it fixes struct declaration.
 
-Next step is to remove initial dot from keywords and then add a semicolon at the end of every label declaration.
+Next step is to remove initial dot from keywords and then add a semicolon at the end of every label and const declaration.
 
 This sequence is repeated for every file specificated as argument and edited file are saved in output folder.

--- a/test_converter.py
+++ b/test_converter.py
@@ -78,6 +78,11 @@ class TestClass(unittest.TestCase):
     expected = "label "
     self.assertEqual(remove_inital_dot_from_keywords(sourceCode), expected, "Should not have initial dot")
 
+  def testremoveInitalDotFromKeywordsConst(self):
+    sourceCode = ".const "
+    expected = "const "
+    self.assertEqual(remove_inital_dot_from_keywords(sourceCode), expected, "Should not have initial dot")
+
   def testremoveInitalDotFromKeywordsPseudocommand(self):
     sourceCode = ".pseudocommand "
     expected = "pseudocommand "
@@ -87,6 +92,11 @@ class TestClass(unittest.TestCase):
     sourceCode = "label xyz = $beef"
     expected = "label xyz = $beef;"
     self.assertEqual(add_semicolon_to_label_declaration(sourceCode), expected, "Should have semicolon at end")
+
+  def testAddSemicolonToConst(self):
+    sourceCode = "const xyz = $beef"
+    expected = "const xyz = $beef;"
+    self.assertEqual(add_semicolon_to_const_declaration(sourceCode), expected, "Should have semicolon at end")
 
   def testRemoveSomeNewLine(self):
     sourceCode = "\n\n\n/**"


### PR DESCRIPTION
Processing for `.const` statements, dot removed from beginning and semicolon added to end of statement.

Closes #3